### PR TITLE
Execute test_chrome before monitoring loop

### DIFF
--- a/SniperX V2.py
+++ b/SniperX V2.py
@@ -841,6 +841,7 @@ if __name__ == "__main__":
                     continue
 
             if csv_has_data(results_csv_path):
+                subprocess.run([sys.executable, os.path.join(SCRIPT_DIRECTORY, 'test_chrome.py')])
                 subprocess.run([sys.executable, os.path.join(SCRIPT_DIRECTORY, 'risk_detector.py')])
                 subprocess.run([sys.executable, os.path.join(SCRIPT_DIRECTORY, 'Monitoring.py')])
 


### PR DESCRIPTION
## Summary
- run `test_chrome.py` whenever results CSV has entries so the Chrome browser test executes before risk detection and monitoring

## Testing
- `python -m py_compile 'SniperX V2.py'`

------
https://chatgpt.com/codex/tasks/task_e_687c2c78a108832cb4d1a3cdbd6e4e04