### PR TITLE
Fix monitoring exit behavior

### DIFF
--- a/Monitoring.py
+++ b/Monitoring.py
@@ -357,8 +357,8 @@ async def main():
             mint_address, token_name = load_token_from_csv(INPUT_CSV_FILE)
             
             if not mint_address:
-                await asyncio.sleep(CSV_CHECK_INTERVAL_SECONDS)
-                continue
+                print("No tokens available for monitoring. Exiting...")
+                return
 
             g_current_mint_address = mint_address
             g_token_name = token_name


### PR DESCRIPTION
## Summary
- ensure `Monitoring.py` exits when there are no tokens

## Testing
- `flake8 .`
- `pytest -q` *(fails: `test_process_window_async` assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_687c3b47dffc832c95213f9a34e7414c